### PR TITLE
Fix header text in HTML report

### DIFF
--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -45,7 +45,7 @@ def generate_html_report(
     html += df_tree.to_html(index=False, border=1, justify="left")
 
     # Sección EEE
-    html += "<h2>3. Métrico EEE y Metadatos</h2>"
+    html += "<h2>3. Métricas EEE y Metadatos</h2>"
     html += df_eee.to_html(index=False, border=1, justify="left")
 
     html += "</body></html>"


### PR DESCRIPTION
## Summary
- fix Spanish header wording in report generator

## Testing
- `pip install pandas` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840ae7f48fc8326a851bbfa08583b4b